### PR TITLE
Security & Performance

### DIFF
--- a/src/hooks/useCloudinary/index.js
+++ b/src/hooks/useCloudinary/index.js
@@ -1,7 +1,7 @@
 import cloudinary from 'cloudinary-core'
 
 export default function useCloudinary({ cloud_name } = {}) {
-  const cld = cloudinary.Cloudinary.new({ cloud_name });
+  const cld = cloudinary.Cloudinary.new({ cloud_name }, { secure: true });
 
   return { cld, cloudinaryCore: cloudinary };
 }

--- a/src/hooks/useGif/index.js
+++ b/src/hooks/useGif/index.js
@@ -3,7 +3,7 @@ import { useQuery } from 'react-query';
 import cloudinary from 'cloudinary-core'
 
 export default function useGif({ cloud_name }) {
-  const cld = cloudinary.Cloudinary.new({ cloud_name })
+  const cld = cloudinary.Cloudinary.new({ cloud_name }, { secure: true })
 
   const [gifOptions, setGifOptions] = React.useState({
     public_id: '',

--- a/src/hooks/useImage/index.js
+++ b/src/hooks/useImage/index.js
@@ -3,7 +3,7 @@ import { useQuery } from 'react-query'
 import cloudinary from 'cloudinary-core'
 
 export default function useImage({ cloud_name } = {}) {
-  const cld = cloudinary.Cloudinary.new({ cloud_name })
+  const cld = cloudinary.Cloudinary.new({ cloud_name }, { secure: true })
 
   if (!cloud_name) {
     throw new Error("Must enter a cloud name")
@@ -25,6 +25,14 @@ export default function useImage({ cloud_name } = {}) {
   function getImage({ public_id, transform_options } = {}) {
     if (!public_id) {
       throw new Error("Must provide a public id of your asset")
+    }
+    if (
+      (transform_options.hasOwnProperty('width') || transform_options.hasOwnProperty('height'))
+      && !transform_options.hasOwnProperty('crop')) {
+        transform_options.crop = 'scale';
+    }
+    if (!transform_options.hasOwnProperty('fetchFormat')) {
+        transform_options.fetchFormat = 'auto';
     }
     return setImageOptions({ public_id, transform_options });
   }

--- a/src/hooks/useVideo/index.js
+++ b/src/hooks/useVideo/index.js
@@ -3,7 +3,7 @@ import { useQuery } from 'react-query';
 import cloudinary from 'cloudinary-core'
 
 export default function useVideo({ cloud_name }) {
-  const cld = cloudinary.Cloudinary.new({ cloud_name })
+  const cld = cloudinary.Cloudinary.new({ cloud_name }, { secure: true })
 
   const [videoOptions, setVideoOptions] = React.useState({
     public_id: '',


### PR DESCRIPTION
1. Enforcing `https` via `{ secure: true }`. There shouldn't be a need to use `http` to serve the images.
2. Enforcing `f_auto` - always serve the best image format for the requesting browser.
3. Added an option that overwrites the underlying `cloudinary-core` functionality for `url()`: if a `width` or `height` option is specified without a `crop`, `{ crop: 'scale' }` is implied.