### PR TITLE
README: Add dependency array to useEffect() hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ function Image({ publicId, transformations, width, height, alt }) {
         
       }
     });
-  });
+  }, [publicId, height, width, transformations]);
 
   // status can either be "success", "loading", or "error"
   if (status === 'loading') return <p>Loading...</p>;


### PR DESCRIPTION
Leaving this dependency array out of the `useEffect()` hook here causes react to slowly eat itself alive - this should make it so that this demo code works out of the box, and responds to changes in height/width/transformations if needed.